### PR TITLE
Prebuilt multiarch legacy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ script:
 
   # macos - only supporting Node.js 8+
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then prebuild -t 8.0.0 -t 10.0.0 -t 11.0.0 -t 12.0.0 ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then prebuild -t 4.0.0 -t 4.0.4 -t 5.0.0 -r electron ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then prebuild -t 3.0.0 -t 4.0.0 -t 4.0.4 -t 5.0.0 -r electron ; fi
 
   # windows - older versions of node to not work - only supporting Node.js 10+
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then prebuild -t 10.0.0 -t 11.0.0 -t 12.0.0 --include-regex "\.(node|exe|dll|pdb)$" ; fi

--- a/src/unix/pty.cc
+++ b/src/unix/pty.cc
@@ -34,7 +34,16 @@
 #if defined(__GLIBC__) || defined(__CYGWIN__)
 #include <pty.h>
 #elif defined(__APPLE__) || defined(__OpenBSD__) || defined(__NetBSD__)
+/**
+ * From node v0.10.28 (at least?) there is also a "util.h" in node/src, which
+ * confuses the compiler when looking for "util.h".
+ * without this compiles of electron 3.x in macOS fail.
+ */
+#if NODE_VERSION_AT_LEAST(10, 0, 0)
+#include <../include/util.h>
+#else
 #include <util.h>
+#endif
 #elif defined(__FreeBSD__)
 #include <libutil.h>
 #elif defined(__sun)


### PR DESCRIPTION
This does what was discussed,

How do you feel about removing the electron 3.x Windows from `prebuilt-multiarch` branch and add it in this new branch instead?

Thanks again in advance.