### PR TITLE
disable yarn gpg and fix windows build timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ matrix:
 
     # windows
     - os: windows
+      env:
+        - YARN_GPG=no
       language: node_js
       node_js:
         - "lts/*"


### PR DESCRIPTION
@oznu this fixes the Windows builds 10min no input error

https://travis-ci.org/the-j0k3r/node-pty-prebuilt-multiarch

Turns out that the yarn install script is calling GPG and this causes the hang.

We can finally enjoy a green passing badge =)